### PR TITLE
Make entityUuid not required

### DIFF
--- a/src/operations/mutation/create_service_account.js
+++ b/src/operations/mutation/create_service_account.js
@@ -5,7 +5,7 @@ class CreateServiceAccount extends BaseOperation {
     this.name = "createServiceAccount";
     this.typeDef = `
       # Create a Service Account
-      createServiceAccount(label: String!, category: String!, type: EntityType!, uuid: Uuid!) : ServiceAccount
+      createServiceAccount(label: String!, category: String!, type: EntityType!, entityUuid: Uuid) : ServiceAccount
     `;
     this.entrypoint = "mutation";
     this.guards = ["authenticated"];


### PR DESCRIPTION
Logic already allowed for a null entityUuid so this PR

- clarifies uuid is entityUuid
- makes entityUuid optional