### PR TITLE
Add workspace obj to results

### DIFF
--- a/src/services/deployment.js
+++ b/src/services/deployment.js
@@ -9,6 +9,7 @@ class DeploymentService extends BaseService {
     const deployments = await this.model("deployment")
       .query()
       .leftJoin("user_workspace_map", "user_workspace_map.workspace_uuid", "deployments.workspace_uuid")
+      .leftJoin("workspace", "deployments.workspace_uuid", "workspace.uuid")
       .where({
         "user_workspace_map.user_uuid": userUuid
       })


### PR DESCRIPTION
This PR

- adds workspace object to results so that clients can report on workspace information when querying all deployments